### PR TITLE
Added optional base_url configuration parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,6 +33,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('secret_key')->defaultValue('')->end()
+                ->scalarNode('base_url')->defaultValue('')->end()
                 ->booleanNode('debug')->defaultValue($this->debug)->end()
             ->end();
 

--- a/DependencyInjection/KnpDisqusExtension.php
+++ b/DependencyInjection/KnpDisqusExtension.php
@@ -39,6 +39,9 @@ class KnpDisqusExtension extends Extension
         if (isset($config['secret_key'])) {
             $container->setParameter('knp_disqus.secret_key', $config['secret_key']);
         }
+        if (isset($config['base_url'])) {
+            $container->setParameter('knp_disqus.base_url', $config['base_url']);
+        }
         $container->setParameter('knp_disqus.debug', (int) $config['debug']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/Disqus.php
+++ b/Disqus.php
@@ -22,7 +22,7 @@ class Disqus
     /**
      * @var string
      */
-    const DISQUS_URL = 'https://disqus.com/api/3.0/';
+    protected $baseUrl = 'https://disqus.com/api/3.0/';
 
     /**
      * @var \Symfony\Component\DependencyInjection\ContainerInterface
@@ -57,14 +57,19 @@ class Disqus
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      * @param string $apiKey
+     * @param string $secretKey
+     * @param string $baseUrl
      * @param int    $debug
      */
-    public function __construct(ContainerInterface $container, $apiKey, $secretKey = null, $debug = 0)
+    public function __construct(ContainerInterface $container, $apiKey, $secretKey = null, $baseUrl = null, $debug = 0)
     {
         $this->container = $container;
 
         $this->apiKey    = $apiKey;
         $this->secretKey = $secretKey;
+        if ($baseUrl) {
+            $this->baseUrl = $baseUrl;
+        }
         $this->debug     = $debug;
     }
 
@@ -165,7 +170,7 @@ class Disqus
         }
 
         // @todo this should be more based on API docs (many params for many different fetch routes)
-        return self::DISQUS_URL.$fetch.'.'.$format.'?thread'.$id.'&forum='.$this->shortname.'&api_key='.$this->apiKey;
+        return $this->baseUrl.$fetch.'.'.$format.'?thread'.$id.'&forum='.$this->shortname.'&api_key='.$this->apiKey;
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="service_container" />
             <argument>%knp_disqus.api_key%</argument>
             <argument>%knp_disqus.secret_key%</argument>
+            <argument>%knp_disqus.base_url%</argument>
             <argument>%kernel.debug%</argument>
         </service>
 

--- a/Tests/DependencyInjection/KnpDisqusExtensionTest.php
+++ b/Tests/DependencyInjection/KnpDisqusExtensionTest.php
@@ -14,6 +14,7 @@ namespace Knp\Bundle\DisqusBundle\Tests\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Parser;
 
+use Knp\Bundle\DisqusBundle\Disqus;
 use Knp\Bundle\DisqusBundle\DependencyInjection\KnpDisqusExtension;
 
 class KnpDisqusExtensionTest extends \PHPUnit_Framework_TestCase
@@ -39,6 +40,17 @@ class KnpDisqusExtensionTest extends \PHPUnit_Framework_TestCase
         $this->createConfiguration('empty');
 
         $this->assertEquals('SECRET_KEY', $this->configuration->getParameter('knp_disqus.secret_key'));
+    }
+
+    public function testBaseUrlParameter()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+
+        $disqus = new Disqus($container, 'PUBLIC_KEY', null, 'http://disqus.com/api/3.0/');
+
+        $content = $disqus->fetch('test', array('identifier' => 'lorem'));
+
+        $this->assertEquals(array('code' => 5, 'response' => 'Invalid API key'), $content);
     }
 
     public function testDebugParameter()


### PR DESCRIPTION
... useful when debugging or when cURL has issues handling SSL. By default the SSL version is used.
