### PR TITLE
Actually using the limit option

### DIFF
--- a/Disqus.php
+++ b/Disqus.php
@@ -215,9 +215,11 @@ class Disqus
         if (!isset($id)) {
             throw new \InvalidArgumentException('You need to give an id.');
         }
+        
+        $limit = isset($options['limit']) ? $options['limit'] : 25;
 
         // @todo this should be more based on API docs (many params for many different fetch routes)
-        return $this->baseUrl.$fetch.'.'.$format.'?thread'.$id.'&forum='.$this->shortname.'&api_key='.$this->apiKey;
+        return $this->baseUrl.$fetch.'.'.$format.'?thread'.$id.'&forum='.$this->shortname.'&api_key='.$this->apiKey.'&limit='.$limit;
     }
 
     /**


### PR DESCRIPTION
A fix to use the `limit` option in the Disqus class.

I just wanted a quick sanity check on this - it seems pretty harmless.

Source: http://disqus.com/api/docs/threads/listPosts/
