### PR TITLE
Changing composer.json to support Symfony 2.4 and higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 
     "require": {
         "php":                      ">=5.3.3",
-        "symfony/framework-bundle": ">=2.0,<2.4-dev",
+        "symfony/framework-bundle": "~2.0",
         "kriswallsmith/buzz":       "~0.7"
     },
 


### PR DESCRIPTION
Hi guys!

I don't actually know if this bundle will have any incompatibilities with Symfony 2.4, but it seems unlikely. This obviously just allows the Symfony version go higher.

Thanks!
