### PR TITLE
support for curl timeout parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Knp\Bundle\DisqusBundle\DependencyInjection;
 
+use Knp\Bundle\DisqusBundle\Disqus;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -34,6 +35,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('secret_key')->defaultValue('')->end()
                 ->scalarNode('base_url')->defaultValue('')->end()
+                ->scalarNode('curl_timeout')->defaultValue(Disqus::DEFAULT_TIMEOUT)->end()
                 ->booleanNode('debug')->defaultValue($this->debug)->end()
             ->end();
 

--- a/DependencyInjection/KnpDisqusExtension.php
+++ b/DependencyInjection/KnpDisqusExtension.php
@@ -43,6 +43,7 @@ class KnpDisqusExtension extends Extension
             $container->setParameter('knp_disqus.base_url', $config['base_url']);
         }
         $container->setParameter('knp_disqus.debug', (int) $config['debug']);
+        $container->setParameter('knp_disqus.curl_timeout', (int) $config['curl_timeout']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Disqus.php
+++ b/Disqus.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Disqus
 {
+    const DEFAULT_TIMEOUT = 5;
+
     /**
      * @var string
      */
@@ -41,6 +43,10 @@ class Disqus
      * @var integer
      */
     protected $debug;
+    /**
+     * @var integer
+     */
+    protected $timeout;
 
     protected $id;
 
@@ -64,7 +70,7 @@ class Disqus
      * @param string $baseUrl
      * @param int    $debug
      */
-    public function __construct(ContainerInterface $container, $apiKey, $secretKey = null, $baseUrl = null, $debug = 0)
+    public function __construct(ContainerInterface $container, $apiKey, $secretKey = null, $baseUrl = null, $debug = 0, $timeout = self::DEFAULT_TIMEOUT)
     {
         $this->container = $container;
 
@@ -75,6 +81,7 @@ class Disqus
         if ($baseUrl) {
             $this->baseUrl = $baseUrl;
         }
+        $this->timeout = $timeout;
     }
 
     /**
@@ -270,12 +277,16 @@ class Disqus
      */
     protected function httpRequest($url, $method = RequestInterface::METHOD_GET)
     {
-        $buzz = new Browser(new Curl());
+        $curl = new Curl();
+        $curl->setTimeout($this->timeout);
+        $buzz = new Browser($curl);
 
         try {
             $response = $buzz->call($url, $method);
         } catch (\RuntimeException $e) {
-            return false;
+            return array(
+                'response' => $e->getMessage(),
+            );
         }
 
         return $response->getContent();

--- a/Disqus.php
+++ b/Disqus.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Disqus
 {
-    const DEFAULT_TIMEOUT = 5;
+    const DEFAULT_TIMEOUT = 8;
 
     /**
      * @var string
@@ -284,8 +284,11 @@ class Disqus
         try {
             $response = $buzz->call($url, $method);
         } catch (\RuntimeException $e) {
-            return array(
-                'response' => $e->getMessage(),
+            return json_encode(
+                array(
+                    'code' => $e->getCode(),
+                    'response' => $e->getMessage(),
+                )
             );
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,6 +17,7 @@
             <argument>%knp_disqus.secret_key%</argument>
             <argument>%knp_disqus.base_url%</argument>
             <argument>%kernel.debug%</argument>
+            <argument>%knp_disqus.curl_timeout%</argument>
         </service>
 
         <service id="knp_disqus.helper" class="%knp_disqus.helper.class%">

--- a/Tests/DependencyInjection/KnpDisqusExtensionTest.php
+++ b/Tests/DependencyInjection/KnpDisqusExtensionTest.php
@@ -72,7 +72,7 @@ class KnpDisqusExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->createConfiguration('full');
 
-        $this->assertEquals(4, $this->configuration->getParameter('knp_disqus.curl_timeout'));
+        $this->assertEquals(8, $this->configuration->getParameter('knp_disqus.curl_timeout'));
     }
 
     public function testCacheKeyParameter()
@@ -108,7 +108,7 @@ EOF;
                 $yaml = <<<EOF
 api_key: PUBLIC_KEY
 secret_key: SECRET_KEY
-curl_timeout: 4
+curl_timeout: 8
 forums:
     lorem:
         cache: test_cache_key

--- a/Tests/DependencyInjection/KnpDisqusExtensionTest.php
+++ b/Tests/DependencyInjection/KnpDisqusExtensionTest.php
@@ -64,6 +64,17 @@ class KnpDisqusExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $this->configuration->getParameter('knp_disqus.debug'));
     }
 
+    public function testCurlTimeoutParameter()
+    {
+        $this->createConfiguration('empty');
+
+        $this->assertEquals(Disqus::DEFAULT_TIMEOUT, $this->configuration->getParameter('knp_disqus.curl_timeout'));
+
+        $this->createConfiguration('full');
+
+        $this->assertEquals(4, $this->configuration->getParameter('knp_disqus.curl_timeout'));
+    }
+
     public function testCacheKeyParameter()
     {
         $this->createConfiguration('full');
@@ -97,6 +108,7 @@ EOF;
                 $yaml = <<<EOF
 api_key: PUBLIC_KEY
 secret_key: SECRET_KEY
+curl_timeout: 4
 forums:
     lorem:
         cache: test_cache_key


### PR DESCRIPTION
In order to allow slow connections (for instance in my vagrant development) is not enough with the 5 seconds of Buzz/Curl timeout default.