### PR TITLE
Bring back twig extension

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,6 +17,11 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="knp_disqus.disqus_client"/>
             <argument>%kernel.environment%</argument>
+            <tag name="twig.runtime" />
+        </service>
+               
+        <service id="Knp\Bundle\DisqusBundle\Twig\Extension\DisqusExtension">
+            <tag name="twig.extension" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Unfortunately, we forgot to register twig extension and runtime, that's why it wasn't available. This change should fix extension and runtime registering!